### PR TITLE
Also export node flow stats for k8s HPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,14 @@ Prometheus exporter for metrics provided by [Node Stats API](https://www.elastic
 ```bash
 $ git clone https://github.com/sap/prometheus-logstash-exporter.git
 $ cd prometheus-logstash-exporter
-$ CGO_ENABLED=0 go build -o prometheus-logstash-exporter
+$ mkdir -p dist
+$ CGO_ENABLED=0 go build -o dist/prometheus-logstash-exporter
 ```
 
 ## Running
 
 ```bash
-./prometheus-logstash-exporter <flags>
+./dist/prometheus-logstash-exporter <flags>
 ```
 
 *If you hold Logstash defaults, the Exporter follow them too.*
@@ -27,8 +28,8 @@ $ CGO_ENABLED=0 go build -o prometheus-logstash-exporter
 To see all available configuration flags:
 
 ```bash
-$ ./prometheus-logstash-exporter -h
-Usage of ./prometheus-logstash-exporter:
+$ ./dist/prometheus-logstash-exporter -h
+Usage of ./dist/prometheus-logstash-exporter:
   -logstash.host string
         Host address of logstash server. (default "localhost")
   -logstash.port int

--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 }
 
 func (e *Exporter) collectMetrics(stats *Stats, ch chan<- prometheus.Metric) {
-	for _, k := range []string{"jvm", "events", "process", "reloads"} {
+	for _, k := range []string{"jvm", "events", "process", "reloads", "flow"} {
 		if tree, ok := (*stats)[k]; ok {
 			e.collectTree(k, tree, prometheus.Labels{}, ch)
 		}


### PR DESCRIPTION
# Add top-level flow metrics to Logstash exporter

## Description
This PR adds support for collecting and exporting top-level flow metrics from Logstash. These metrics provide valuable insights into the performance and behavior of Logstash pipelines, which can be useful for monitoring and potentially for Horizontal Pod Autoscaling (HPA) in Kubernetes environments.

## Changes
- Modified the `collectMetrics` function to include "flow" in the list of top-level metrics to collect.
- The existing `collectTree` function now handles the nested structure of flow metrics automatically, creating appropriate Prometheus metrics for each value.

## Benefits
- Provides more comprehensive metrics about Logstash performance.
- Enables better monitoring and potential autoscaling based on flow metrics.
- Implements the change in a simple and consistent manner with existing code.

## Testing
I have tested this change locally and confirmed that the new flow metrics are correctly exported and can be scraped by Prometheus.

## Notes
This change only adds top-level flow metrics and does not include per-pipeline flow metrics. If per-pipeline flow metrics are desired in the future, further modifications would be needed.